### PR TITLE
Update travis job to enable cares support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ notifications:
   email:
     - team@appwrite.io
 
-before_script: 
-  - pecl install --configureoptions 'enable-sockets="yes" enable-openssl="yes" enable-http2="yes" enable-mysqlnd="yes" enable-swoole-json="no" enable-swoole-curl="yes"' swoole
+before_script:
+  - sudo apt-get update
+  - sudo apt-get -y install libc-ares-dev
+  - pecl install --configureoptions 'enable-sockets="yes" enable-openssl="yes" enable-http2="yes" enable-mysqlnd="yes" enable-swoole-json="no" enable-swoole-curl="yes" enable-cares="yes"' swoole
   - composer install --ignore-platform-reqs
 
 script:


### PR DESCRIPTION
The build currently fails with:

```shell
$ pecl install --configureoptions 'enable-sockets="yes" enable-openssl="yes" enable-http2="yes" enable-mysqlnd="yes" enable-swoole-json="no" enable-swoole-curl="yes"' swoole
downloading swoole-4.8.12.tgz ...
Starting to download swoole-4.8.12.tgz (2,097,350 bytes)
.............................................................................................................................................................................................................................................................................................................................................................................................................................done: 2,097,350 bytes
413 source files, building
running: phpize
Configuring for:
PHP Api Version:         20200930
Zend Module Api No:      20200930
Zend Extension Api No:   420200930
enable cares support? [no] : 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
The build has been terminated
```

This PR attempts to fix this.