### PR TITLE
feat: add onRequest method to WebSocket adapters

### DIFF
--- a/src/WebSocket/Adapter.php
+++ b/src/WebSocket/Adapter.php
@@ -83,6 +83,13 @@ abstract class Adapter
     abstract public function onMessage(callable $callback): self;
 
     /**
+     * Is called when an HTTP request is received.
+     * @param callable $callback
+     * @return self
+     */
+    abstract public function onRequest(callable $callback): self;
+
+    /**
      * Is called when a connection is closed.
      * @param callable $callback
      * @return self

--- a/src/WebSocket/Adapter/Swoole.php
+++ b/src/WebSocket/Adapter/Swoole.php
@@ -3,6 +3,7 @@
 namespace Utopia\WebSocket\Adapter;
 
 use Swoole\Http\Request;
+use Swoole\Http\Response;
 use Swoole\Process;
 use Swoole\WebSocket\Frame;
 use Swoole\WebSocket\Server;
@@ -120,6 +121,15 @@ class Swoole extends Adapter
             unset(self::$connections[$fd]);
 
             call_user_func($callback, $fd);
+        });
+
+        return $this;
+    }
+
+    public function onRequest(callable $callback): self
+    {
+        $this->server->on('request', function (Request $request, Response $response) use ($callback) {
+            call_user_func($callback, $request, $response);
         });
 
         return $this;

--- a/src/WebSocket/Adapter/Workerman.php
+++ b/src/WebSocket/Adapter/Workerman.php
@@ -104,6 +104,13 @@ class Workerman extends Adapter
         return $this;
     }
 
+    public function onRequest(callable $callback): self
+    {
+        $this->server->onRequest = $callback;
+
+        return $this;
+    }
+
     public function setPackageMaxLength(int $bytes): self
     {
         return $this;

--- a/src/WebSocket/Server.php
+++ b/src/WebSocket/Server.php
@@ -197,6 +197,24 @@ class Server
     }
 
     /**
+     * Is called when an HTTP request is received.
+     * @param callable $callback
+     * @return self
+     */
+    public function onRequest(callable $callback): self
+    {
+        try {
+            $this->adapter->onRequest($callback);
+        } catch (Throwable $error) {
+            foreach ($this->errorCallbacks as $errorCallback) {
+                $errorCallback($error, 'onRequest');
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Returns all connections.
      *
      * @return array<mixed>

--- a/tests/servers/Workerman/server.php
+++ b/tests/servers/Workerman/server.php
@@ -55,7 +55,7 @@ $server
                              'Content-Type: application/json' . "\r\n" .
                              'Connection: close' . "\r\n\r\n" .
                              json_encode(['status' => 'ok', 'message' => 'WebSocket server is running']));
-        } elseif ($request->path() === '/info') {
+        } elseif ($path === '/info') {
             $connection->send('HTTP/1.1 200 OK' . "\r\n" .
                              'Content-Type: application/json' . "\r\n" .
                              'Connection: close' . "\r\n\r\n" .

--- a/tests/servers/Workerman/server.php
+++ b/tests/servers/Workerman/server.php
@@ -44,9 +44,13 @@ $server
         }
     })
     ->onRequest(function (TcpConnection $connection, Request $request) use ($server) {
-        echo 'HTTP request received: ', $request->path(), PHP_EOL;
+        $path = $request->path();
+        if (!is_string($path)) {
+            throw new \Exception('Invalid path ' . $path . ' for request: ' . json_encode($request, JSON_PRETTY_PRINT));
+        }
+        echo 'HTTP request received: ', $path, PHP_EOL;
 
-        if ($request->path() === '/health') {
+        if ($path === '/health') {
             $connection->send('HTTP/1.1 200 OK' . "\r\n" .
                              'Content-Type: application/json' . "\r\n" .
                              'Connection: close' . "\r\n\r\n" .

--- a/tests/servers/Workerman/server.php
+++ b/tests/servers/Workerman/server.php
@@ -3,6 +3,8 @@
 require_once __DIR__.'/../../../vendor/autoload.php';
 
 use Utopia\WebSocket;
+use Workerman\Connection\TcpConnection;
+use Workerman\Protocols\Http\Request;
 
 $adapter = new WebSocket\Adapter\Workerman();
 $adapter->setWorkerNumber(1); // Important for tests
@@ -39,6 +41,29 @@ $server
                 $server->send([$connection], 'disconnect');
                 $server->close($connection, 1000);
                 break;
+        }
+    })
+    ->onRequest(function (TcpConnection $connection, Request $request) use ($server) {
+        echo 'HTTP request received: ', $request->path(), PHP_EOL;
+
+        if ($request->path() === '/health') {
+            $connection->send('HTTP/1.1 200 OK' . "\r\n" .
+                             'Content-Type: application/json' . "\r\n" .
+                             'Connection: close' . "\r\n\r\n" .
+                             json_encode(['status' => 'ok', 'message' => 'WebSocket server is running']));
+        } elseif ($request->path() === '/info') {
+            $connection->send('HTTP/1.1 200 OK' . "\r\n" .
+                             'Content-Type: application/json' . "\r\n" .
+                             'Connection: close' . "\r\n\r\n" .
+                             json_encode([
+                                 'server' => 'Workerman WebSocket',
+                                 'connections' => count($server->getConnections()),
+                                 'timestamp' => time()
+                             ]));
+        } else {
+            $connection->send('HTTP/1.1 404 Not Found' . "\r\n" .
+                             'Connection: close' . "\r\n\r\n" .
+                             'Not Found');
         }
     })
     ->start();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling HTTP requests directly in the WebSocket server through a new event handler.
  * Introduced customizable HTTP endpoints, including `/health` for server status and `/info` for server metadata.
  * Enhanced both Swoole and Workerman adapters to allow registration of HTTP request callbacks.

* **Tests**
  * Added test handlers for HTTP endpoints to verify server status and information responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->