### PR TITLE
fix: only use COMPRESS flag when compression is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 .phpunit*
 .idea
+.DS_Store

--- a/src/WebSocket/Adapter/Swoole.php
+++ b/src/WebSocket/Adapter/Swoole.php
@@ -44,14 +44,19 @@ class Swoole extends Adapter
 
     public function send(array $connections, string $message): void
     {
+        $flags = SWOOLE_WEBSOCKET_FLAG_FIN;
+        if ($this->config['websocket_compression'] ?? false) {
+            $flags |= SWOOLE_WEBSOCKET_FLAG_COMPRESS;
+        }
+
         foreach ($connections as $connection) {
-            go(function () use ($connection, $message) {
+            go(function () use ($connection, $message, $flags) {
                 if ($this->server->exist($connection) && $this->server->isEstablished($connection)) {
                     $this->server->push(
                         $connection,
                         $message,
                         SWOOLE_WEBSOCKET_OPCODE_TEXT,
-                        SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_COMPRESS
+                        $flags
                     );
                 } else {
                     $this->server->close($connection);


### PR DESCRIPTION
## Summary
- Only include `SWOOLE_WEBSOCKET_FLAG_COMPRESS` when `websocket_compression` is enabled in config
- Fixes compatibility issues with Swoole 6.1.6 when clients don't support permessage-deflate

## Problem
The `SWOOLE_WEBSOCKET_FLAG_COMPRESS` flag was hardcoded in the `send()` method, regardless of whether compression was actually enabled. With Swoole 6.1.6, this caused issues when sending messages to clients that don't support the permessage-deflate extension.

## Solution
Check the `websocket_compression` config value before including the compress flag in the push flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude macOS system metadata files.

* **New Features**
  * WebSocket adapter now supports message compression when enabled in configuration, improving bandwidth efficiency for WebSocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->